### PR TITLE
Use standard delegate pattern

### DIFF
--- a/kvdag.gemspec
+++ b/kvdag.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.summary	= 'Direct Acyclical Graph for KeyValue searches'
   s.description	= File.read(File.join(File.dirname(__FILE__), 'README.md'))
   s.homepage    = 'https://github.com/saab-simc-admin/keyvaluedag'
-  s.version	= '0.0.1'
+  s.version	= '0.0.2'
   s.author	= 'Calle Englund'
   s.email	= 'calle.englund@saabgroup.com'
   s.license	= 'MIT'

--- a/lib/kvdag/keypathhash.rb
+++ b/lib/kvdag/keypathhash.rb
@@ -1,7 +1,8 @@
+require 'delegate'
 require 'active_support/core_ext/hash'
 
 class KVDAG
-  class KeyPathHashProxy
+  class KeyPathHashProxy < DelegateClass(Hash)
     class KeyPath < Array
       private :initialize
       def initialize(keypath)
@@ -14,16 +15,9 @@ class KVDAG
     def initialize(hash = {})
       raise TypeError.new("Must be initialized with a `hash`") unless hash.is_a?(Hash)
       @hash = hash.deep_stringify_keys
+      super(@hash)
     end
     
-    def method_missing(name, *args, &block)
-      @hash.send(name, *args, &block)
-    end
-
-    def to_hash
-      @hash
-    end
-
     def merge(other, &block)
       self.class.new(@hash.deep_merge(other.deep_stringify_keys, &block))
     end


### PR DESCRIPTION
Rebased pull request for the new properly root signed master branch.

Use the standard Ruby delegate pattern instead of rolling our own method_missing.
