### PR TITLE
Filter keypaths

### DIFF
--- a/kvdag.gemspec
+++ b/kvdag.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.summary	= 'Direct Acyclical Graph for KeyValue searches'
   s.description	= File.read(File.join(File.dirname(__FILE__), 'README.md'))
   s.homepage    = 'https://github.com/saab-simc-admin/keyvaluedag'
-  s.version	= '0.0.2'
+  s.version	= '0.0.3'
   s.author	= 'Calle Englund'
   s.email	= 'calle.englund@saabgroup.com'
   s.license	= 'MIT'

--- a/lib/kvdag/attrnode.rb
+++ b/lib/kvdag/attrnode.rb
@@ -35,5 +35,19 @@ class KVDAG
       @attrs.merge!(other.to_hash)
       self
     end
+
+    # Filter the key-value view of a vertex by a list of key prefixes,
+    # and return a hash_proxy containing only those trees.
+    #
+    # :call-seq:
+    #   filter("key.path1", ..., "key.pathN") -> hash_proxy
+
+    def filter(*keys)
+      if self.respond_to?(:to_hash_proxy) then
+        to_hash_proxy.filter(*keys)
+      else
+        raise NotImplementedError.new("not implemented for plain hash")
+      end
+    end
   end
 end

--- a/lib/kvdag/attrnode.rb
+++ b/lib/kvdag/attrnode.rb
@@ -2,15 +2,21 @@ class KVDAG
   module AttributeNode
     attr_reader :attrs
 
-    def [](attr, options = {})
+    def fetch(attr, options = {})
       case
       when (options[:shallow])
-        @attrs[attr]
+        @attrs.fetch(attr)
       when self.respond_to?(:to_hash_proxy)
-        to_hash_proxy[attr]
+        to_hash_proxy.fetch(attr)
       else
-        to_hash[attr]
+        to_hash.fetch(attr)
       end
+    end
+
+    def [](attr, options = {})
+      fetch(attr, options)
+    rescue
+      nil
     end
 
     def []=(attr, value)

--- a/lib/kvdag/keypathhash.rb
+++ b/lib/kvdag/keypathhash.rb
@@ -27,12 +27,38 @@ class KVDAG
       self
     end
 
-    def [](keypath)
-      *keypath, key = KeyPath.new(keypath)
+    # :call-seq:
+    #   fetch("key.path")      -> value or KeyError
+    #   fetch(["key", "path"]) -> value or KeyError
+    #
+    # Return the value at a specified keypath. If the keypath
+    # does not specify a terminal value, return the remaining
+    # subtree instead.
+    #
+    # Raises a KeyError exception if the keypath is not found.
+
+    def fetch(keypath)
+      *keysubpath, key = KeyPath.new(keypath)
       hash = @hash
 
-      keypath.each {|key| hash = hash[key]}
-      hash[key]
+      keysubpath.each {|key| hash = hash.fetch(key)}
+      hash.fetch(key)
+    rescue KeyError
+      raise KeyError.new("keypath not found: #{keypath.inspect}")
+    end
+
+    # :call-seq:
+    #   fetch("key.path")      -> value or nil
+    #   fetch(["key", "path"]) -> value or nil
+    #
+    # Return the value at a specified keypath. If the keypath
+    # does not specify a terminal value, return the remaining
+    # subtree instead.
+    #
+    # Returns nil if the keypath is not found.
+
+    def [](keypath)
+      fetch(keypath)
     rescue
       nil
     end

--- a/lib/kvdag/keypathhash.rb
+++ b/lib/kvdag/keypathhash.rb
@@ -76,5 +76,22 @@ class KVDAG
 
       hash[key] = value
     end
+
+    # :call-seq:
+    #   filter("key.path1", ..., "key.pathN") -> KeyPathHashProxy
+    #
+    # Filter a keypathhash tree by a list of keypath prefixes, and
+    # return a new keypathhash containing only those trees.
+    #
+    # Raises a KeyError exception if any of the specified keypaths
+    # cannot be found.
+
+    def filter(*keypaths)
+      result = self.class.new
+      keypaths.each do |keypath|
+        result[keypath] = self.fetch(keypath)
+      end
+      result
+    end
   end
 end


### PR DESCRIPTION
PalletJack needs filtering capabilities from underlying KVDAG::Vertex objects.

This implements a `#filter` method that filters key-value content by a list of key.paths.
