### PR TITLE
Flip the table on family relations

### DIFF
--- a/kvdag.gemspec
+++ b/kvdag.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.summary	= 'Direct Acyclical Graph for KeyValue searches'
   s.description	= File.read(File.join(File.dirname(__FILE__), 'README.md'))
   s.homepage    = 'https://github.com/saab-simc-admin/keyvaluedag'
-  s.version	= '0.0.3'
+  s.version	= '0.1.0'
   s.author	= 'Calle Englund'
   s.email	= 'calle.englund@saabgroup.com'
   s.license	= 'MIT'

--- a/lib/kvdag/vertex.rb
+++ b/lib/kvdag/vertex.rb
@@ -20,9 +20,13 @@ class KVDAG
 
     alias to_s inspect
 
-    alias children edges
+    # Return the set of all direct parents
 
-    def parents
+    alias parents edges
+
+    # Return the set of all direct children
+
+    def children
       result = Set.new
       dag.vertices.each do |vertex|
         next if vertex.equal?(self)
@@ -44,13 +48,21 @@ class KVDAG
       other.reachable?(self)
     end
 
-    def decendants
+    # Return the set of all parents, and their parents, recursively
+    #
+    # This is the same as all <tt>reachable?</tt> vertices.
+
+    def ancestors
       result = Set.new
       dag.vertices.each {|vertex| result << vertex if reachable?(vertex)}
       result
     end
 
-    def ancestors
+    # Return the set of all children, and their children, recursively
+    #
+    # This is the same as all <tt>reachable_from?</tt> vertices.
+
+    def descendants
       result = Set.new
       dag.vertices.each {|vertex| result << vertex if reachable_from?(vertex)}
       result


### PR DESCRIPTION
Previously, the vertices reachable by an edge were incorrectly
considered children of a vertex, and vice versa. The proper
semantics is that edges point to parents, because that's the
way key-values are inherited.

Also, the `descendants` method was misspelled.

This flips the table and turns everything upside-down.
Anyone using these methods will get broken by this change:
- `Vertex#parents`
- `Vertex#children`
- `Vertex#ancestors`
- `Vertex#decendants` [sic]
