### PR TITLE
Return parent vertices instead of edges

### DIFF
--- a/lib/kvdag/vertex.rb
+++ b/lib/kvdag/vertex.rb
@@ -31,7 +31,9 @@ class KVDAG
 
     # Return the set of all direct parents
 
-    alias parents edges
+    def parents
+      return Set.new(edges.map do |edge| edge.to_vertex end)
+    end
 
     # Return the set of all direct children
 

--- a/lib/kvdag/vertex.rb
+++ b/lib/kvdag/vertex.rb
@@ -32,7 +32,7 @@ class KVDAG
     # Return the set of all direct parents
 
     def parents
-      return Set.new(edges.map do |edge| edge.to_vertex end)
+      return Set.new(edges.map {|edge| edge.to_vertex})
     end
 
     # Return the set of all direct children


### PR DESCRIPTION
The `children` function returns vertices. The documentation for `parents` suggests it will return vertices. However, it actually returns edges. Change it to return vertices instead.
