### PR TITLE
Child traversal

### DIFF
--- a/kvdag.gemspec
+++ b/kvdag.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.summary	= 'Direct Acyclical Graph for KeyValue searches'
   s.description	= File.read(File.join(File.dirname(__FILE__), 'README.md'))
   s.homepage    = 'https://github.com/saab-simc-admin/keyvaluedag'
-  s.version	= '0.1.0'
+  s.version	= '0.1.1'
   s.author	= 'Calle Englund'
   s.email	= 'calle.englund@saabgroup.com'
   s.license	= 'MIT'

--- a/lib/kvdag/attrnode.rb
+++ b/lib/kvdag/attrnode.rb
@@ -70,5 +70,46 @@ class KVDAG
         raise NotImplementedError.new("not implemented for plain hash")
       end
     end
+
+    # :call-seq:
+    #   match?()                           -> true
+    #   match?(method: match, ...)         -> true or false
+    #   match?(one?:{ matches }, ...)      -> true or false
+    #   match?(any?:{ matches }, ...)      -> true or false
+    #   match?(all?:{ matches }, ...)      -> true of false
+    #   match?(none?:{ matches }, ...)     -> true or false
+    #
+    # Checks if the key-value view visible from a node matches all of
+    # set of filters. An empty filter set is considered a match.
+    #
+    # Any +method+ given will be matched against its result:
+    #   match === self.send(method)
+    #
+    # +matches+ should be a hash with 'key.path' strings at keys,
+    # and +match+ values to check for equality:
+    #   match === self[key]
+    #
+    # Examples:
+    #
+    #   node.match?(class:KVDAG::Vertex)
+    #   node.match?(none?:{'key' => Integer})
+    #   node.match?(all?:{'key' => /this|that/})
+    #   node.match?(any?:{'key1' => 'this', 'key2' => 'that'})
+    #   node.match?(one?:{'key1' => 'this', 'key2' => 'that'})
+
+    def match?(filter={})
+      valid_enumerators = [:none?, :one?, :any?, :all?]
+
+      filter.all? do |item|
+        method, match = item
+        if valid_enumerators.include?(method)
+          match.send(method) do |item|
+            value === self[key]
+          end
+        else
+          match === self.send(method)
+        end
+      end
+    end
   end
 end

--- a/lib/kvdag/vertex.rb
+++ b/lib/kvdag/vertex.rb
@@ -35,17 +35,33 @@ class KVDAG
       return Set.new(edges.map {|edge| edge.to_vertex})
     end
 
-    # Return the set of all direct children
+    # :call-seq:
+    #   vtx.children                 -> all children
+    #   vtx.children(filter)         -> children matching +filter+
+    #   vtx.children {|cld| ... }    -> call block with each child
+    #
+    # Returns the set of all direct children, possibly filtered by #match?
+    # expressions. If a block is given, call it with each child.
 
-    def children
+    def children(filter={}, &block)
       result = Set.new
+
       dag.vertices.each do |vertex|
         next if vertex.equal?(self)
         vertex.edges.each do |edge|
-          result << vertex if edge.to_vertex.equal?(self)
+          if edge.to_vertex.equal?(self)
+            if vertex.match?(filter)
+              result << vertex if edge.to_vertex.equal?(self)
+            end
+          end
         end
       end
-      result
+
+      if block_given?
+        result.each(&block)
+      else
+        result
+      end
     end
 
     # Is +other+ vertex reachable via any of my #edges?


### PR DESCRIPTION
Extend the functionality of the `Vertex#children` method to support filtering the resulting set, by help of `AttributeNode#match?`.

Also allow calling a block with each resulting child, if given.
