### PR TITLE
Correct matching against keypath values

### DIFF
--- a/lib/kvdag/attrnode.rb
+++ b/lib/kvdag/attrnode.rb
@@ -103,7 +103,8 @@ class KVDAG
       filter.all? do |item|
         method, match = item
         if valid_enumerators.include?(method)
-          match.send(method) do |item|
+          match.send(method) do |match_item|
+            key, value = match_item
             value === self[key]
           end
         else


### PR DESCRIPTION
Matching against keypath values contained in the attributenode
didn't actually work, because parameter splitting was missing.
Also, for less confusing code, don't overload nested iterator
parameter names.
