### PR TITLE
Extend #parents with filter and block processing

### DIFF
--- a/kvdag.gemspec
+++ b/kvdag.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.summary	= 'Direct Acyclical Graph for KeyValue searches'
   s.description	= File.read(File.join(File.dirname(__FILE__), 'README.md'))
   s.homepage    = 'https://github.com/saab-simc-admin/keyvaluedag'
-  s.version	= '0.1.1'
+  s.version	= '0.1.2'
   s.author	= 'Calle Englund'
   s.email	= 'calle.englund@saabgroup.com'
   s.license	= 'MIT'

--- a/lib/kvdag/vertex.rb
+++ b/lib/kvdag/vertex.rb
@@ -29,10 +29,26 @@ class KVDAG
 
     alias to_s inspect
 
-    # Return the set of all direct parents
+    # :call-seq:
+    #   vtx.parents                 -> all parents
+    #   vtx.parents(filter)         -> parents matching +filter+
+    #   vtx.parents {|cld| ... }    -> call block with each parent
+    #
+    # Returns the set of all direct parents, possibly filtered by #match?
+    # expressions. If a block is given, call it with each parent.
 
-    def parents
-      return Set.new(edges.map {|edge| edge.to_vertex})
+    def parents(filter={}, &block)
+      result = Set.new(edges.map {|edge|
+                         edge.to_vertex
+                       }.select {|parent|
+                         parent.match?(filter)
+                       })
+
+      if block_given?
+        result.each(&block)
+      else
+        result
+      end
     end
 
     # :call-seq:


### PR DESCRIPTION
KVDAG::Vertex#parents has been extended with the same API for
filtering and block processing as #children was in #8.
