### PR TITLE
Import `bundle gem` generated scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,9 @@ build-iPhoneSimulator/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
-# .ruby-version
-# .ruby-gemset
+Gemfile.lock
+.ruby-version
+.ruby-gemset
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in kvdag.gemspec
+gemspec

--- a/README.md
+++ b/README.md
@@ -34,6 +34,44 @@ install`.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at
-https://github.com/saab-simc-admin/kvdag.
+We are happy to accept contributions in the form of issues and pull
+requests on
+[GitHub](https://github.com/saab-simc-admin/keyvaluedag). Please
+follow these guidelines to make the experience as smooth as possible:
+
+- All development takes place in feature branches, with master only
+  accepting non-fast-forward merges.
+
+- Others shall be able to use the KeyValue DAG library to build their
+  own tools. If you introduce API changes, please increment version
+  numbers according to [semantic versioning](http://semver.org/).
+
+- All code will be reviewed before it is merged. To help the reviewer,
+  send your work as a series of logically separate changes, not as one
+  gigantic squash commit. Make sure bisection will work by ensuring
+  the code actually works after each change.
+
+- GnuPG sign all your commits and tags, with a key that is [validated
+  by
+  GitHub](https://help.github.com/articles/about-gpg-commit-and-tag-signatures/).
+
+  - GitHub's web UI cannot generate signed merges when accepting pull
+    requests. Instead, we use [a custom
+    tool](https://github.com/saab-simc-admin/workflow-tools/tree/master/git-ghpr)
+    to accept them. You can still send them through the web as usual.
+
+  - Your code shall be signed by you. Therefore, the maintainer cannot
+    fix any merge conflicts arising from your pull request. If there
+    are any conflicts, please rebase onto current master before
+    sending your pull request.
+
+- Document your work.
+
+  - At an absolute minimum, Ruby code shall have
+    [RDoc](https://rdoc.github.io/rdoc/) blocks documenting each
+    function.
+
+  - Write your commit messages in the usual Git style: a short summary
+    in the first line, then paragraphs of explanatory text, line
+    wrapped.
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,7 @@ dependencies. Then, run `rake spec` to run the tests. You can also run
 experiment.
 
 To install this gem onto your local machine, run `bundle exec rake
-install`. To release a new version, update the version number in
-`version.rb`, and then run `bundle exec rake release`, which will
-create a git tag for the version, push git commits and tags, and push
-the `.gem` file to [rubygems.org](https://rubygems.org).
+install`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-# keyvaluedag
-DAG for keyvalue searches
+# KVDAG
+
+Implements a Directed Acyclic Graph for Key-Value searches.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'kvdag'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install kvdag
+
+## Usage
+
+TODO: Write usage instructions here
+
+## Development
+
+After checking out the repo, run `bin/setup` to install
+dependencies. Then, run `rake spec` to run the tests. You can also run
+`bin/console` for an interactive prompt that will allow you to
+experiment.
+
+To install this gem onto your local machine, run `bundle exec rake
+install`. To release a new version, update the version number in
+`version.rb`, and then run `bundle exec rake release`, which will
+create a git tag for the version, push git commits and tags, and push
+the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/saab-simc-admin/kvdag.
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "kvdag"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/kvdag.gemspec
+++ b/kvdag.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~>2'
   spec.add_runtime_dependency 'activesupport', '~>4'
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rake", "~> 0.9"
+  spec.add_development_dependency "rspec", "~> 2.14"
 end

--- a/kvdag.gemspec
+++ b/kvdag.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~>2'
   spec.add_runtime_dependency 'activesupport', '~>4'
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 0.9"
-  spec.add_development_dependency "rspec", "~> 2.14"
+  spec.add_development_dependency "bundler", "~> 1.7.8"
+  spec.add_development_dependency "rake", "~> 0.9.6"
+  spec.add_development_dependency "rspec", "~> 2.14.1"
 end

--- a/kvdag.gemspec
+++ b/kvdag.gemspec
@@ -1,20 +1,33 @@
 #-*- ruby -*-
-Gem::Specification.new do |s|
-  s.name	= 'kvdag'
-  s.summary	= 'Direct Acyclical Graph for KeyValue searches'
-  s.description	= File.read(File.join(File.dirname(__FILE__), 'README.md'))
-  s.homepage    = 'https://github.com/saab-simc-admin/keyvaluedag'
-  s.version	= '0.1.2'
-  s.author	= 'Calle Englund'
-  s.email	= 'calle.englund@saabgroup.com'
-  s.license	= 'MIT'
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'kvdag/version'
 
-  s.platform	= Gem::Platform::RUBY
-  s.required_ruby_version = '~>2'
-  s.add_runtime_dependency 'activesupport', '~>4'
-  s.files	= [ 'README.md', 'LICENSE' ]
-  s.files	+= Dir['lib/**/*.rb']
-  s.executables	= []
-  s.test_files	= Dir['test/test*.rb']
-  s.has_rdoc	= true
+Gem::Specification.new do |spec|
+  spec.name	= 'kvdag'
+  spec.version  = KVDAG::VERSION
+  spec.summary	= 'Directed Acyclic Graph for Key-Value searches'
+  spec.description	= spec.summary
+  spec.homepage    = 'https://github.com/saab-simc-admin/keyvaluedag'
+  spec.authors	= ['Calle Englund']
+  spec.email	= ['calle.englund@saabgroup.com']
+  spec.license	= 'MIT'
+
+  spec.has_rdoc	= true
+
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.platform	= Gem::Platform::RUBY
+  spec.required_ruby_version = '~>2'
+  spec.add_runtime_dependency 'activesupport', '~>4'
+
+  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/kvdag.rb
+++ b/lib/kvdag.rb
@@ -1,4 +1,5 @@
 require 'active_support'
+require "kvdag/version"
 require 'kvdag/error'
 require 'kvdag/attrnode'
 require 'kvdag/vertex'

--- a/lib/kvdag/version.rb
+++ b/lib/kvdag/version.rb
@@ -1,0 +1,3 @@
+class KVDAG
+  VERSION = '0.1.2'
+end

--- a/spec/kvdag_spec.rb
+++ b/spec/kvdag_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe KVDAG do
+  it "has a version number" do
+    expect(KVDAG::VERSION).not_to be nil
+  end
+
+  it "does something useful" do
+    expect(false).to eq(true)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "kvdag"


### PR DESCRIPTION
Import the scaffolding that would have been created if we initialized the project with `bundle gem`, instead of starting from scratch. This adds project support for testing and release management, including publishing to a gem server, with the help of `rake`.
