### PR TITLE
Allow filtering of vertices.

### DIFF
--- a/lib/kvdag.rb
+++ b/lib/kvdag.rb
@@ -11,9 +11,6 @@ require 'kvdag/keypathhash'
 class KVDAG
   include Enumerable
 
-  # Return the set of all vertices
-  attr_reader :vertices
-
   attr_reader :hash_proxy_class
 
   # Create a new KVDAG, optionally using a specialized
@@ -47,15 +44,25 @@ class KVDAG
     KVDAG::Vertex.new(self, attrs)
   end
 
+  # Return the set of all vertices, possibly filtered by
+  # Vertex#match? expressions.
+
+  def vertices(filter = {})
+    return @vertices if filter.empty?
+
+    Set.new(@vertices.select{|vertex| vertex.match?(filter) })
+  end
+
   # Return the set of all edges
 
   def edges
     @vertices.reduce(Set.new) {|edges,vertex| edges + vertex.edges}
   end
 
-  # Enumerate all vertices in the DAG
+  # Enumerate all vertices in the DAG, possibly filtered
+  # by Vertex#match? expressions.
 
-  def each(&block)
-    @vertices.each(&block)
+  def each(filter = {}, &block)
+    vertices(filter).each(&block)
   end
 end

--- a/lib/kvdag/version.rb
+++ b/lib/kvdag/version.rb
@@ -1,3 +1,3 @@
 class KVDAG
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/spec/kvdag_spec.rb
+++ b/spec/kvdag_spec.rb
@@ -105,4 +105,28 @@ describe KVDAG do
       }.to raise_error KVDAG::CyclicError
     end
   end
+
+  context 'when vertices and edges have attributes' do
+    before :each do
+      @dag = KVDAG.new
+      @v1 = @dag.vertex(first: true)
+      @v2 = @dag.vertex(second: true)
+      @v1.edge @v2, edge: true
+    end
+
+    it 'can be filtered by vertex attribute' do
+      expect(@dag.vertices(all?:{'first' => true})).to include @v1
+      expect(@dag.vertices(all?:{'first' => true})).not_to include @v2
+    end
+
+    it 'can be filtered by edge attribute' do
+      expect(@dag.vertices(all?:{'edge' => true})).to include @v1
+      expect(@dag.vertices(all?:{'edge' => true})).not_to include @v2
+    end
+
+    it 'can be filtered by parent attribute' do
+      expect(@dag.vertices(all?:{'second' => true})).to include @v1
+      expect(@dag.vertices(all?:{'second' => true})).to include @v2
+    end
+  end
 end


### PR DESCRIPTION
The `#vertices` method has been extended to optionally take `AttributeNode#match?` filters to select a subset of all vertices.

This bumps gem micro version for API change.
