### PR TITLE
Revert to modern versions of dev tools

### DIFF
--- a/kvdag.gemspec
+++ b/kvdag.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~>2'
   spec.add_runtime_dependency 'activesupport', '~>4'
 
-  spec.add_development_dependency "bundler", "~> 1.7.8"
-  spec.add_development_dependency "rake", "~> 0.9.6"
+  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-collection_matchers", "~> 1.1.2"
 


### PR DESCRIPTION
The versions provided by CentOS are too outdated to be useful, so use current versions from rubygems instead.