### PR TITLE
Extend distant relatives with filtering

### DIFF
--- a/lib/kvdag/version.rb
+++ b/lib/kvdag/version.rb
@@ -1,3 +1,3 @@
 class KVDAG
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/lib/kvdag/vertex.rb
+++ b/lib/kvdag/vertex.rb
@@ -92,27 +92,48 @@ class KVDAG
       other.reachable?(self)
     end
 
-    # Return the set of this object and all its parents, and their
-    # parents, recursively
+    # :call-seq:
+    #   vtx.ancestors                 -> all ancestors
+    #   vtx.ancestors(filter)         -> ancestors matching +filter+
+    #   vtx.ancestors {|anc| ... }    -> call block with each ancestor
     #
-    # This is the same as all #reachable? vertices.
+    # Return the set of this object and all its parents, and their
+    # parents, recursively, possibly filtered by #match?
+    # expressions. If a block is given, call it with each ancestor.
 
+    def ancestors(filter={}, &block)
+      result = Set.new
+      result << self if match?(filter)
 
-    def ancestors
-      result = Set.new([self])
-      parents.each {|p| result += p.ancestors }
-      result
+      parents.each {|p| result += p.ancestors(filter) }
+
+      if block_given?
+        result.each(&block)
+      else
+        result
+      end
     end
 
-    # Return the set of this object and all its children, and their
-    # children, recursively
+    # :call-seq:
+    #   vtx.descendants                 -> all descendants
+    #   vtx.descendants(filter)         -> descendants matching +filter+
+    #   vtx.descendants {|desc| ... }   -> call block with each descendant
     #
-    # This is the same as all #reachable_from? vertices.
+    # Return the set of this object and all its children, and their
+    # children, recursively, possibly filtered by #match?
+    # expressions. If a block is given, call it with each descendant.
 
-    def descendants
-      result = Set.new([self])
-      children.each {|c| result += c.descendants }
-      result
+    def descendants(filter={}, &block)
+      result = Set.new
+      result << self if match?(filter)
+
+      children.each {|c| result += c.descendants(filter) }
+
+      if block_given?
+        result.each(&block)
+      else
+        result
+      end
     end
 
     # Comparable ordering for a DAG:

--- a/spec/kvdag-vertex_spec.rb
+++ b/spec/kvdag-vertex_spec.rb
@@ -135,4 +135,51 @@ describe KVDAG::Vertex do
       expect(@v3.reachable_from? @v4).to be false
     end
   end
+
+  context 'filtered ancestry' do
+    before :all do
+      # v1 --> v2 --> v3
+      # v4 -/     \-> v5
+
+      @dag = KVDAG.new
+      @v1 = @dag.vertex v1: true
+      @v2 = @dag.vertex v2: true
+      @v3 = @dag.vertex v3: true
+      @v4 = @dag.vertex v4: true
+      @v5 = @dag.vertex v5: true
+
+      @v1.edge @v2
+      @v4.edge @v2
+      @v2.edge @v3
+      @v2.edge @v5
+    end
+
+    it 'can filter direct parents' do
+      parents = @v2.parents(all?:{'v3' => true})
+      expect(parents).to include @v3
+      #expect(parents).not_to include @v5
+    end
+
+    it 'can filter direct children' do
+      children = @v2.children(all?:{'v1' => true})
+      expect(children).to include @v1
+      #expect(children).not_to include @v4
+    end
+
+    it 'can filter ancestors' do
+      ancestors = @v1.ancestors(all?:{'v3' => true})
+      expect(ancestors).to include @v1
+      expect(ancestors).to include @v2
+      expect(ancestors).to include @v3
+      #expect(ancestors).not_to include @v5
+    end
+
+    it 'can filter descendants' do
+      descendants = @v3.descendants(all?:{'v2' => true})
+      expect(descendants).to include @v1
+      expect(descendants).to include @v2
+      #expect(descendants).not_to include @v3
+      expect(descendants).to include @v4
+    end
+  end
 end


### PR DESCRIPTION
The previously implemented vertex filtering API for direct children and parents is needed for distant relatives as well.

`Vertex#ancestors` and `Vertex#descendants` now have the same filtering and iteration API as `#children` and `#parents`.