### PR TITLE
Fix updated rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 Style/IndentArray:
   EnforcedStyle: consistent
-Style/MethodName: 
-  EnforcedStyle: snake_case 
+Style/MethodName:
+  EnforcedStyle: snake_case
 Style/SymbolArray:
   EnforcedStyle: brackets

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,8 @@
 inherit_from: .rubocop_todo.yml
+
+Style/IndentArray:
+  EnforcedStyle: consistent
+Style/MethodName: 
+  EnforcedStyle: snake_case 
+Style/SymbolArray:
+  EnforcedStyle: brackets

--- a/kvdag.gemspec
+++ b/kvdag.gemspec
@@ -1,5 +1,6 @@
 #-*- ruby -*-
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'kvdag/version'


### PR DESCRIPTION
When updated to the latest `rubocop` (0.48.0), a few new offenses were detected. This PR fixes those offenses, and brings rubocop tuning in sync with saab-simc-admin/palletjack#116.