### PR TITLE
RuboCop updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 inherit_from: .rubocop_todo.yml
 
-Style/IndentArray:
+Layout/IndentArray:
   EnforcedStyle: consistent
 Style/MethodName:
   EnforcedStyle: snake_case

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -90,7 +90,7 @@ Style/EmptyLiteral:
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: AllowForAlignment, ForceEqualSignAlignment.
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
   Exclude:
     - 'kvdag.gemspec'
 
@@ -132,7 +132,7 @@ Style/IfInsideElse:
 
 # Offense count: 4
 # Cop supports --auto-correct.
-Style/LeadingCommentSpace:
+Layout/LeadingCommentSpace:
   Exclude:
     - 'spec/kvdag-vertex_spec.rb'
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,8 @@ RSpec::Core::RakeTask.new(:spec)
 desc 'Run Rubocop'
 require 'rubocop'
 require 'rubocop/rake_task'
-RuboCop::RakeTask.new(:rubocop)
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.options += ['--display-cop-names']
+end
 
 task :default => [:rubocop, :spec]

--- a/kvdag.gemspec
+++ b/kvdag.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.1.2'
-  spec.add_development_dependency 'rubocop', '~> 0.46'
+  spec.add_development_dependency 'rubocop', '~> 0.49'
 end

--- a/lib/kvdag/version.rb
+++ b/lib/kvdag/version.rb
@@ -1,3 +1,3 @@
 class KVDAG
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
Update RuboCop to 0.49, and configure it to always show cop names when run through Rake.